### PR TITLE
🐛  Crashes Node-Red when Cloudflare session is expired #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # node-red-dashboard-2-cloudflare-auth
 
+Enables Cloudflare Access user auth information to be passed to Node-RED.
+
 This authentication plugin was made for the fantastic [Node-RED Dashboard 2](https://github.com/FlowFuse/node-red-dashboard) project by [FlowFuse](https://github.com/FlowFuse). 
 It enables those using [Cloudflare Access](https://www.cloudflare.com/zero-trust/products/access/) to receive user information such as email address in Node-RED anytime they interact with Dashboard elements. This can be useful for configuring authorization (authz) rules, or for per-user scoped reads/writes, etc. 
 
@@ -10,6 +12,7 @@ Pre-requisites:
 - A Cloudflare [tunnel configured for your Node-RED instance](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/)
 - A Cloudflare [access policy configured for your Node-RED instance](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/)
 
+Steps:
 1. Install @flowfuse/node-red-dashboard 
 
 2. Install `@fullmetal-fred/node-red-dashboard-2-cloudflare-auth` via npm or flows.nodered.org
@@ -23,10 +26,11 @@ Pre-requisites:
 
 ## Contributing
 
+Pull requests and issues welcome! 
+
 In order to develop:
 
 1. Clone the repo
 2. Optionally run the devcontainer in vscode
-3. 'npm start' for local Node-RED instance with the module installed
+3. 'npm run dev' for local Node-RED instance with the module installed
 
-Pull requests and issues welcome! 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullmetal-fred/node-red-dashboard-2-cloudflare-auth",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "When used with Cloudflare Access authentication, this plugin will pass the email address of an authenticated user into the _client object under _client.user.email",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Issue was occuring when Node-RED was restarted while dashboard was open it seems. Fixed by handling missing msg._client. 

Also improve user object structure and logging